### PR TITLE
Updating to the latest version of less4j.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -4,7 +4,7 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.5.1"]
-                 [com.github.sommeri/less4j "1.2.3"]
+                 [com.github.sommeri/less4j "1.8.0"]
                  [optimus "0.13.5"]]
   :profiles {:dev {:dependencies [[midje "1.5.0"]
                                   [test-with-files "0.1.0"]]


### PR DESCRIPTION
The latest version of less4j seems to be a drop-in replacement, and has several bug fixes.
