### PR TITLE
Add less4j-javascript

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -5,6 +5,7 @@
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.5.1"]
                  [com.github.sommeri/less4j "1.8.5"]
+                 [com.github.sommeri/less4j-javascript "0.0.1"]
                  [optimus "0.17.1"]]
   :profiles {:dev {:dependencies [[midje "1.6.3"]
                                   [test-with-files "0.1.0"]]

--- a/src/optimus_less/core.clj
+++ b/src/optimus_less/core.clj
@@ -2,12 +2,15 @@
   (:require [clojure.string :as str]
             [optimus.assets.load-css :refer [create-css-asset]]
             [optimus.assets.creation :refer [last-modified existing-resource]])
-  (:import [com.github.sommeri.less4j.core DefaultLessCompiler]))
+  (:import [com.github.sommeri.less4j.core DefaultLessCompiler ]
+           com.github.sommeri.less4j_javascript.Less4jJavascript))
 
 (defn compile-less [less]
-  (-> (DefaultLessCompiler.)
-      (.compile less)
-      (.getCss)))
+  (let [config (com.github.sommeri.less4j.LessCompiler$Configuration.)]
+    (Less4jJavascript/configure config)
+    (-> (DefaultLessCompiler.)
+      (.compile less config)
+      (.getCss))))
 
 (defn load-less-asset [public-dir path]
   (let [resource (existing-resource public-dir path)]


### PR DESCRIPTION
Adds support for ~`JS syntax in less files. TIL ~` is valid syntax in .less, which allows the user to write functions in JS. This pull adds the less4j-javascript plugin to compile those files. 

Testing: My designer wrote some less.js containing ~``. Those files didn't compile in less4j until this I made change.  That's the only testing I've done on this. 
